### PR TITLE
test: adapter axios to http protocol unit tests

### DIFF
--- a/src/infra/adapters/AdapterAxiosToHttpProtocol.test.ts
+++ b/src/infra/adapters/AdapterAxiosToHttpProtocol.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it, vi } from 'vitest'
+import {AdapterAxiosToHttpProtocol} from './AdapterAxiosToHttpProtocol'
+import axios from 'axios'
+
+const makeSut = ()=>{
+    const sut =  new AdapterAxiosToHttpProtocol()
+    const requestSpy = vi.spyOn(axios,'request')
+    return{
+        sut,
+        requestSpy
+    }
+}
+
+describe('AdapterAxiosToHttpProtocol',()=>{
+    it('should call axios with correct params',async ()=>{
+        const {sut, requestSpy} = makeSut()
+        const mockTestUrl = 'fake-test-url'
+        requestSpy.mockResolvedValueOnce({
+            data:{apiStubData:'bar'},
+            status:200
+        })
+
+        await sut.request({
+            url: mockTestUrl,
+            method: "GET"
+        })
+
+        expect(requestSpy).toHaveBeenCalledWith({
+            url:mockTestUrl,
+            method:'GET'
+        })
+    })
+})

--- a/src/infra/adapters/AdapterAxiosToHttpProtocol.test.ts
+++ b/src/infra/adapters/AdapterAxiosToHttpProtocol.test.ts
@@ -30,4 +30,26 @@ describe('AdapterAxiosToHttpProtocol',()=>{
             method:'GET'
         })
     })
+
+    it('should return correct response when request fails',()=>{
+        const {sut, requestSpy} = makeSut()
+        const mockTestUrl = 'fake-test-url'
+        requestSpy.mockRejectedValueOnce({response:{
+            data:{apiStubData:'bar'},
+            status:589
+        }})
+
+        const result =  sut.request({
+            url: mockTestUrl,
+            method: "GET"
+        })
+
+        expect(result).resolves.toEqual({
+            body: {
+                apiStubData:'bar',
+            },
+            statusCode:589
+        })
+
+    })
 })

--- a/src/infra/adapters/AdapterAxiosToHttpProtocol.test.ts
+++ b/src/infra/adapters/AdapterAxiosToHttpProtocol.test.ts
@@ -52,4 +52,26 @@ describe('AdapterAxiosToHttpProtocol',()=>{
         })
 
     })
+
+    it('should return parsed data on success request',async()=>{
+        const {sut, requestSpy} = makeSut()
+        const mockResponse = {
+            data:{apiStubData:'bar'},
+            status:200
+        }
+        requestSpy.mockResolvedValueOnce({
+            data:{apiStubData:'bar'},
+            status:200
+        })
+
+        const result = await sut.request({
+            url: 'stub-url',
+            method: "GET"
+        })
+
+        expect(result).toEqual({
+            body:mockResponse.data,
+            statusCode:mockResponse.status
+        })
+    })
 })


### PR DESCRIPTION
add unit tests to axios adapter to http protocol to ensure correct usage of axios library with application http protocol in success and error scenarios.